### PR TITLE
Publish python builds for python 3.8 and 3.9, and explicitly for 3.10

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -9,9 +9,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build and publish to pypi
-        uses: agates/poetry-publish@v1.10-beta.4
+      - name: Build and publish to pypi (3.10)
+        uses: JRubics/poetry-publish@v1.10
         with:
+          python_version: "3.10.2"
+          ignore_dev_requirements: "yes"
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          extra_build_dependency_packages: "capnproto libzmq3-dev"
+      - name: Build and publish to pypi (3.9)
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          python_version: "3.9.10"
+          ignore_dev_requirements: "yes"
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          extra_build_dependency_packages: "capnproto libzmq3-dev"
+      - name: Build and publish to pypi (3.8)
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          python_version: "3.8.12"
           ignore_dev_requirements: "yes"
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           extra_build_dependency_packages: "capnproto libzmq3-dev"


### PR DESCRIPTION
Closes #40
